### PR TITLE
Fixes for v1.0.0-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oscal/oscal-deep-diff",
-  "version": "1.0.0-0",
+  "version": "1.0.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@oscal/oscal-deep-diff",
-      "version": "1.0.0-0",
+      "version": "1.0.0-1",
       "license": "NIST-PD-fallback",
       "dependencies": {
         "commander": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oscal/oscal-deep-diff",
-  "version": "1.0.0-0",
+  "version": "1.0.0-1",
   "description": "A deep diff tool",
   "main": "./lib/index.js",
   "bin": {

--- a/src/base-comparisons/utils.spec.ts
+++ b/src/base-comparisons/utils.spec.ts
@@ -7,6 +7,7 @@ describe('Build Selection Path', () => {
         const comparison: DocumentComparison = {
             leftDocument: '',
             rightDocument: '',
+            score: 0,
             changes: [
                 new ArrayChanged(
                     '/catalog/groups',
@@ -52,6 +53,7 @@ describe('Build Selection Path', () => {
         const comparison: DocumentComparison = {
             leftDocument: '',
             rightDocument: '',
+            score: 0,
             changes: [
                 new ArrayChanged(
                     '/catalog/groups',

--- a/src/cli/cli-utils.ts
+++ b/src/cli/cli-utils.ts
@@ -16,7 +16,7 @@ const YAML_DISCLAIMER = '(this can also be defined via the YAML config)';
 
 export function parseCliOptions(): Config {
     const command = new Command()
-        .version(process.env.npm_package_version ?? 'unknown')
+        .version('v1.0.0-1')
         .description('Deep Differencing of OSCAL JSON artifacts')
         .usage('[options]')
         .option('-c --config <filename>', 'YAML config file to read from')
@@ -42,7 +42,7 @@ export function parseCliOptions(): Config {
     }
 
     if (options.config) {
-        if (Object.keys(rawConfig).length === 0) {
+        if (Object.keys(rawConfig).length !== 0) {
             throw new Error('Base configuration cannot be defined both as an argument and as a file');
         }
 

--- a/src/comparator.ts
+++ b/src/comparator.ts
@@ -48,12 +48,13 @@ export default class Comparator {
         const leftRoot = trackRawObject('', left);
         const rightRoot = trackRawObject('', right);
 
-        const [changes] = this.compareElements(leftRoot, rightRoot);
+        const [changes, score] = this.compareElements(leftRoot, rightRoot);
 
         return {
             leftDocument: leftSource,
             rightDocument: rightSource,
             changes,
+            score,
         };
     }
 

--- a/src/results.ts
+++ b/src/results.ts
@@ -104,4 +104,5 @@ export interface DocumentComparison {
     leftDocument: string;
     rightDocument: string;
     changes: Change[];
+    score: number;
 }


### PR DESCRIPTION
- Enhancement: Display final comparison score in final document output #41
- CLI `--config` flag override logic simple bug #40
- CLI `--version` subcommand returns "unknown" #38

# Committer Notes

{Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title or mark the PR as DRAFT.}

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/oscal-deep-diff/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/oscal-deep-diff/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
- [x] Have you checked to see if any extraneous dependencies are living in [package.json](../package.json) or [package-lock.json](../package-lock.json)?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated readme documentation affected by the changes you made?
