### PR TITLE
Fix cosine similarity denominator double-counting the second vector

### DIFF
--- a/src/utils/string-similarity.spec.ts
+++ b/src/utils/string-similarity.spec.ts
@@ -52,6 +52,19 @@ describe('String Similarity', () => {
         expect(stringSimilarity('aaa', 'aab', 'cosine', false)).equals(stringSimilarity('aaa', 'aba', 'cosine', false));
     });
 
+    it('cosine is bounded by 1 and symmetric for terms with differing magnitudes', () => {
+        // term-frequency vectors: 'a a a b' -> [3, 1], 'a b' -> [1, 1]
+        // dot product is 4, magnitudes are sqrt(10) and sqrt(2), so cosine is 4 / sqrt(20) ~= 0.8944
+        const score = stringSimilarity('a a a b', 'a b', 'cosine', false);
+        expect(score).to.be.closeTo(0.8944, 0.0001);
+        // cosine similarity must never exceed 1
+        expect(score).to.be.at.most(1);
+        // and it must be symmetric regardless of argument order
+        expect(stringSimilarity('a a a b', 'a b', 'cosine', false)).equals(
+            stringSimilarity('a b', 'a a a b', 'cosine', false),
+        );
+    });
+
     it('absolute', () => {
         expect(stringSimilarity('hi there', 'Hi there', 'absolute', false)).equals(0);
         expect(stringSimilarity('hi there', 'Hi there', 'absolute', true)).equals(1);

--- a/src/utils/string-similarity.ts
+++ b/src/utils/string-similarity.ts
@@ -135,7 +135,7 @@ export function cosineSimilarity(s1: string, s2: string): number {
     const termFreqVec1 = termFreqMapToVec(termFreqMap1, termsSet);
     const termFreqVec2 = termFreqMapToVec(termFreqMap2, termsSet);
 
-    return vecDotProduct(termFreqVec1, termFreqVec2) / (vecMagnitude(termFreqVec2) * vecMagnitude(termFreqVec2));
+    return vecDotProduct(termFreqVec1, termFreqVec2) / (vecMagnitude(termFreqVec1) * vecMagnitude(termFreqVec2));
 }
 
 export default function stringSimilarity(s1: string, s2: string, method: string, ignoreCase: boolean): number {


### PR DESCRIPTION
I was looking at the cosine string-similarity method and the denominator in `cosineSimilarity` (src/utils/string-similarity.ts) multiplies the magnitude of the second term-frequency vector by itself:

```
vecDotProduct(v1, v2) / (vecMagnitude(termFreqVec2) * vecMagnitude(termFreqVec2))
```

Cosine similarity is `dot(v1, v2) / (|v1| * |v2|)`, so the first factor should be `|v1|`, not a second copy of `|v2|`. Because of this the score is wrong whenever the two vectors have different magnitudes, it stops being symmetric, and it can even go above 1.

Quick example with `'a a a b'` (vector [3, 1]) and `'a b'` (vector [1, 1]):

- correct value: `4 / (sqrt(10) * sqrt(2))` which is about 0.894
- current behavior: `4 / (sqrt(2) * sqrt(2))` = 2.0 one direction, and 0.4 if you swap the arguments

The fix is a one-token change, using `termFreqVec1` for the first magnitude:

```
vecDotProduct(v1, v2) / (vecMagnitude(termFreqVec1) * vecMagnitude(termFreqVec2))
```

This only affects the `cosine` comparison method (`stringComparisonMethod: 'cosine'`); jaro-winkler and absolute are untouched. The existing cosine tests still pass because they only exercised exact-match, no-match, and a symmetric pair where the bug happened to cancel out. I added a regression test for a pair with differing magnitudes that asserts the score is about 0.894, stays at most 1, and is symmetric. That test fails on the current code and passes with the fix; the full suite goes from 61 to 62 passing and lint is clean.